### PR TITLE
Update for compatability with Laravel 5.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "optimus/api-consumer",
     "require": {
-        "laravel/framework": "~5.1"
+        "laravel/framework": "~5.2"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.7",

--- a/src/Provider/LaravelServiceProvider.php
+++ b/src/Provider/LaravelServiceProvider.php
@@ -14,7 +14,7 @@ class LaravelServiceProvider extends BaseProvider {
 
     public function boot()
     {
-        $this->app->bindShared('apiconsumer', function(){
+        $this->app->singleton('apiconsumer', function(){
             $app = app();
 
             return new Router($app, $app['request'], $app['router']);

--- a/tests/Provider/LaravelServiceProviderTest.php
+++ b/tests/Provider/LaravelServiceProviderTest.php
@@ -8,7 +8,7 @@ class LaravelServiceProviderTest extends Orchestra\Testbench\TestCase {
     {
         $appMock = m::mock('Illuminate\Foundation\Application');
 
-        $appMock->shouldReceive('bindShared')->with(
+        $appMock->shouldReceive('singleton')->with(
             'apiconsumer',
             m::type('Closure')
         );


### PR DESCRIPTION
See the deprecations part of the [upgrade guide](https://laravel.com/docs/5.2/upgrade#upgrade-5.1.11). The `bindShared()` has been renamed to `singleton()` in Laravel 5.2
