### PR TITLE
Add Laravel 6 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,13 +1,13 @@
 {
     "name": "optimus/api-consumer",
     "require": {
-        "laravel/framework": "~5.2"
+        "laravel/framework": "~6.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.7",
-        "orchestra/testbench": "~3.0",
-        "mockery/mockery": "0.9.*",
-        "satooshi/php-coveralls": "dev-master@dev"
+        "phpunit/phpunit": "~8.0",
+        "orchestra/testbench": "4.*",
+        "mockery/mockery": "1.3.*",
+        "php-coveralls/php-coveralls": "2.2.*"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "optimus/api-consumer",
     "require": {
-        "laravel/framework": "~5.2||~6.0"
+        "laravel/framework": "~6.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~8.0",

--- a/composer.json
+++ b/composer.json
@@ -1,13 +1,13 @@
 {
     "name": "optimus/api-consumer",
     "require": {
-        "laravel/framework": "~5.2"
+        "laravel/framework": "~5.2||~6.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.7",
-        "orchestra/testbench": "~3.0",
-        "mockery/mockery": "0.9.*",
-        "satooshi/php-coveralls": "dev-master@dev"
+        "phpunit/phpunit": "~8.0",
+        "orchestra/testbench": "4.*",
+        "mockery/mockery": "1.3.*",
+        "php-coveralls/php-coveralls": "2.2.*"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -7,8 +7,7 @@
      convertNoticesToExceptions="true"
      convertWarningsToExceptions="true"
      processIsolation="false"
-     stopOnFailure="false"
-     syntaxCheck="false">
+     stopOnFailure="false">
      <logging>
         <log type="coverage-clover" target="build/logs/clover.xml"/>
     </logging>

--- a/tests/Provider/LaravelServiceProviderTest.php
+++ b/tests/Provider/LaravelServiceProviderTest.php
@@ -14,7 +14,7 @@ class LaravelServiceProviderTest extends Orchestra\Testbench\TestCase {
         );
 
         $provider = $this->app->make('Optimus\ApiConsumer\Provider\LaravelServiceProvider', [
-            $appMock
+            'app' => $appMock
         ]);
 
         $this->assertNull($provider->register());

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -12,7 +12,7 @@ class RouterTest extends Orchestra\Testbench\TestCase {
 
     private $routerMock;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -21,7 +21,7 @@ class RouterTest extends Orchestra\Testbench\TestCase {
         $this->routerMock = m::mock("Illuminate\Routing\Router");
     }
 
-    public function tearDown()
+    public function tearDown() : void
     {
         parent::tearDown();
 


### PR DESCRIPTION
Added support for Laravel 6
Just updated dependencies and adapted tests for the phpUnit upgraded verison
- Unit Tests running successfully
- As well as a project using the library working with Laravel 6 is also running properly after this changes